### PR TITLE
Convert numeric inputs to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ var entities = require('./entities.json');
 var revEntities = require('./reversed.json');
 
 exports.encode = function (str, opts) {
+    if (typeof str == 'number') {
+        str = String(str);
+    }
+
     if (typeof str !== 'string') {
         throw new TypeError('Expected a String');
     }


### PR DESCRIPTION
I'm getting "TypeError: Expected a String" error when I pass a numeric values to Hyperglue, converting `str` to number will fix that

error stack was;

```
   at Object.exports.encode (/Users/azer/dev/brick-node/node_modules/hyperglue/node_modules/ent/index.js:13:15)
    at Result.setAttribute (/Users/azer/dev/brick-node/node_modules/hyperglue/node_modules/trumpet/index.js:285:51)
    at /Users/azer/dev/brick-node/node_modules/hyperglue/index.js:57:27
```